### PR TITLE
Implement theme switcher and other UI updates

### DIFF
--- a/config/process-bundle.js
+++ b/config/process-bundle.js
@@ -1,12 +1,13 @@
 import browserslist from "browserslist"
-import { transform, browserslistToTargets } from "lightningcss"
+import { transform as cssTransform, browserslistToTargets } from "lightningcss"
+import { transform as jsTransform } from "esbuild"
 
 const targets = browserslistToTargets(browserslist())
 
 /** @param {string} content  */
 export default async function (content) {
   if (this.type === 'css') {
-    let result = transform({
+    let result = cssTransform({
       code: Buffer.from(content),
       minify: true,
       targets
@@ -15,7 +16,7 @@ export default async function (content) {
   }
 
   if (this.type === 'js') {
-    // process js
-    return content
+    let result = await jsTransform(content, { minify: true })
+    return result.code
   }
 }

--- a/src/_components/key.webc
+++ b/src/_components/key.webc
@@ -9,6 +9,7 @@
     background-color: var(--color-key-bg, var(--color-platinum-orange));
     color: var(--color-key-text, var(--color-river-bed));
     font-size: var(--text-key, var(--text-l-fluid));
+    font-weight: inherit;
     letter-spacing: var(--tracking-tighter);
     line-height: normal;
     cursor: pointer;

--- a/src/_components/key.webc
+++ b/src/_components/key.webc
@@ -17,6 +17,7 @@
     padding: 7px 0 0; /* optical adjustment */
     position: relative;
     touch-action: manipulation;
+    transition: background-color 0s;
 
     &:not(:focus-visible) {
       box-shadow: 0 4px 0 0 var(--color-key-shadow, var(--color-martini));

--- a/src/_components/keypad.webc
+++ b/src/_components/keypad.webc
@@ -1,7 +1,7 @@
 <key>7</key>
 <key>8</key>
 <key>9</key>
-<key class="secondary">DEL</key>
+<key class="secondary" aria-label="delete">DEL</key>
 <key>4</key>
 <key>5</key>
 <key>6</key>
@@ -10,9 +10,9 @@
 <key>2</key>
 <key>3</key>
 <key>&minus;</key>
-<key>.</key>
+<key aria-label="decimal point">.</key>
 <key>0</key>
-<key>/</key>
+<key aria-label="divide">/</key>
 <key>&times;</key>
 <key class="secondary big">RESET</key>
 <key class="primary big">=</key>

--- a/src/_components/theme-switch.webc
+++ b/src/_components/theme-switch.webc
@@ -1,36 +1,38 @@
-<fieldset class="theme-switch" role="radiogroup" webc:root="override">
-  <legend class="visually-hidden">Select a theme</legend>
-  <div class="container">
-    <div aria-hidden="true">THEME</div>
-    <div>
-      <div class="labels" aria-hidden="true">
-        <div>1</div>
-        <div>2</div>
-        <div>3</div>
-      </div>
-      <div class="track">
-        <div class="radio-wrapper">
-          <input type="radio" name="theme" id="auto" aria-label="auto">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
-            <circle cx="8" cy="8" r="8" />
-          </svg>
+<form id="theme-switch" webc:root="override">
+  <fieldset class="theme-switch" role="radiogroup">
+    <legend class="visually-hidden">Select a theme</legend>
+    <div class="container">
+      <div aria-hidden="true">THEME</div>
+      <div>
+        <div class="labels" aria-hidden="true">
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
         </div>
-        <div class="radio-wrapper">
-          <input type="radio" name="theme" id="light" aria-label="light" checked>
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
-            <circle cx="8" cy="8" r="8" />
-          </svg>
-        </div>
-        <div class="radio-wrapper">
-          <input type="radio" name="theme" id="dark" aria-label="dark">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
-            <circle cx="8" cy="8" r="8" />
-          </svg>
+        <div class="track">
+          <div class="radio-wrapper">
+            <input type="radio" name="theme" id="dark" value="dark" aria-label="dark theme">
+            <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
+              <circle cx="8" cy="8" r="8" />
+            </svg>
+          </div>
+          <div class="radio-wrapper">
+            <input type="radio" name="theme" id="light" value="light" aria-label="light theme">
+            <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
+              <circle cx="8" cy="8" r="8" />
+            </svg>
+          </div>
+          <div class="radio-wrapper">
+            <input type="radio" name="theme" id="purple" value="purple" aria-label="purple theme">
+            <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true" focusable="false">
+              <circle cx="8" cy="8" r="8" />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</fieldset>
+  </fieldset>
+</form>
 
 <style>
   .theme-switch {
@@ -113,3 +115,81 @@
     }
   }
 </style>
+
+<script>
+  /** @typedef {'light'|'dark'|'purple'} Theme */
+
+  /** @type {Theme} theme - The state that holds the current theme */
+  let theme
+  /** @type {HTMLFormElement} themeSwitch - The DOM element that allows users to change the current theme */
+  let themeSwitch
+
+  /**
+   * Gets the theme preference from the local storage (if set). Otherwise,
+   * returns 'light' or 'dark' depending on the `prefers-color-scheme` value
+   *
+   * @returns {Theme}
+   */
+  function getThemePreference(key = 'theme-preference') {
+    if (localStorage.getItem(key)) {
+      return localStorage.getItem(key)
+    } else {
+      return window.matchMedia('(prefers-color-scheme: light)').matches
+        ? 'light'
+        : 'dark'
+    }
+  }
+
+  /**
+   * Updates the DOM to reflect the theme change
+   */
+  function reflectThemeChange() {
+    document.firstElementChild.setAttribute('data-theme', theme)
+
+    themeSwitch = themeSwitch || document.querySelector('#theme-switch')
+    if (themeSwitch) {
+      const themeRadios = themeSwitch.elements['theme']
+
+      // If needed, check the radio button that corresponds to the current theme
+      if (themeRadios.value !== theme) {
+        const themeRadio = [...themeRadios].find(radio => radio.id === theme)
+        themeRadio.checked = true
+      }
+    }
+  }
+
+  // Save the theme preference into state
+  theme = getThemePreference()
+  // Set the `data-theme` attribute early to prevent page flashes
+  reflectThemeChange()
+</script>
+
+<script webc:bucket="defer">
+  /**
+   * Saves the theme preference in local storage
+   * and updates the DOM to reflect the changes
+   */
+  function setThemePreference(key = 'theme-preference') {
+    localStorage.setItem(key, theme)
+    reflectThemeChange()
+  }
+
+  // Call once DOM is ready to sync radio buttons with the theme state
+  reflectThemeChange()
+
+  // Bind event handlers to update the theme on switch interaction
+  themeSwitch.elements['theme'].forEach(radio => {
+    radio.addEventListener('change', event => {
+      theme = event.target.id
+      setThemePreference()
+    })
+  })
+
+  // Bind event handler to update the theme when `prefers-color-scheme` changes
+  window
+    .matchMedia('(prefers-color-scheme: light)')
+    .addEventListener('change', ({ matches: isLight }) => {
+      theme = isLight ? 'light' : 'dark'
+      setThemePreference()
+    })
+</script>

--- a/src/assets/css/_base.css
+++ b/src/assets/css/_base.css
@@ -56,7 +56,7 @@
              Typography
   *********************************/
 
-  --text-sans: 'League Spartan', Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif;
+  --text-sans: 'League Spartan', Avenir, Montserrat, 'URW Gothic', source-sans-pro, sans-serif;
   --text-bold: 700;
 
   --text-s: 12px;

--- a/src/assets/css/_base.css
+++ b/src/assets/css/_base.css
@@ -72,37 +72,6 @@
   --tracking-wide: 1px;
 
   /*********************************
-    Container-relative fluid props
-  *********************************/
-
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.33—0.47 */
-  --fluid-0\.33-0\.47: clamp(0.0206rem, 0.0007rem + 0.0848cqi, 0.0294rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.53—0.67 */
-  --fluid-0\.53-0\.67: clamp(0.0331rem, 0.0132rem + 0.0848cqi, 0.0419rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.67—0.93 */
-  --fluid-0\.67-0\.93: clamp(0.0419rem, 0.0049rem + 0.1576cqi, 0.0581rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,3—1 */
-  --fluid-3-1: clamp(0.0625rem, 0.4716rem + -1.2121cqi, 0.1875rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,5—10 */
-  --fluid-5-10: clamp(0.3125rem, -0.3977rem + 3.0303cqi, 0.625rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=320,540,10—24 */
-  --fluid-10-24: clamp(0.625rem, -0.6477rem + 6.3636cqi, 1.5rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,20—28 */
-  --fluid-20-28: clamp(1.25rem, 0.1136rem + 4.8485cqi, 1.75rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=320,540,20—32 */
-  --fluid-20-32: clamp(1.25rem, 0.1591rem + 5.4545cqi, 2rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,24—32 */
-  --fluid-24-32: clamp(1.5rem, 0.3636rem + 4.8485cqi, 2rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,32—40 */
-  --fluid-32-40: clamp(2rem, 0.8636rem + 4.8485cqi, 2.5rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,40—56 */
-  --fluid-40-56: clamp(2.5rem, 0.2273rem + 9.697cqi, 3.5rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=320,375,53—64 */
-  --fluid-53-64: clamp(3.3125rem, -0.6875rem + 20cqi, 4rem);
-  /* @link https://utopia.fyi/clamp/calculator?a=375,540,88—128 */
-  --fluid-88-128: clamp(5.5rem, -0.1818rem + 24.2424cqi, 8rem);
-
-  /*********************************
      Viewport-relative fluid props
   *********************************/
 
@@ -110,6 +79,75 @@
   --fluid-4-6: clamp(0.25rem, 0.206rem + 0.1878vi, 0.375rem);
   /* @link https://utopia.fyi/clamp/calculator?a=375,1440,6—9 */
   --fluid-6-9: clamp(0.375rem, 0.309rem + 0.2817vi, 0.5625rem);
+
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,0.33—0.47 */
+  --fluid-0\.33-0\.47: clamp(0.0206rem, 0.0052rem + 0.0657vi, 0.0294rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,0.53—0.67 */
+  --fluid-0\.53-0\.67: clamp(0.0331rem, 0.0177rem + 0.0657vi, 0.0419rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,0.67—0.93 */
+  --fluid-0\.67-0\.93: clamp(0.0419rem, 0.0133rem + 0.1221vi, 0.0581rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,3—1 */
+  --fluid-3-1: clamp(0.0625rem, 0.4076rem + -0.939vi, 0.1875rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,5—10 */
+  --fluid-5-10: clamp(0.3125rem, -0.2377rem + 2.3474vi, 0.625rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,20—28 */
+  --fluid-20-28: clamp(1.25rem, 0.3697rem + 3.7559vi, 1.75rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,24—32 */
+  --fluid-24-32: clamp(1.5rem, 0.6197rem + 3.7559vi, 2rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,32—40 */
+  --fluid-32-40: clamp(2rem, 1.1197rem + 3.7559vi, 2.5rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,40—56 */
+  --fluid-40-56: clamp(2.5rem, 0.7394rem + 7.5117vi, 3.5rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=375,588,88—128 */
+  --fluid-88-128: clamp(5.5rem, 1.0986rem + 18.7793vi, 8rem);
+
+  /* @link https://utopia.fyi/clamp/calculator?a=320,588,10—24 */
+  --fluid-10-24: clamp(0.625rem, -0.4198rem + 5.2239vi, 1.5rem);
+  /* @link https://utopia.fyi/clamp/calculator?a=320,588,20—32 */
+  --fluid-20-32: clamp(1.25rem, 0.3545rem + 4.4776vi, 2rem);
+
+  /* @link https://utopia.fyi/clamp/calculator?a=320,375,53—64 */
+  --fluid-53-64: clamp(3.3125rem, -0.6875rem + 20vi, 4rem);
+
+  /*********************************
+    Container-relative fluid props
+  *********************************/
+
+  /*
+    ✨ Progressive Enhancement ✨
+
+    If the browser supports container query units, make fluid spacing relative
+    to the container (i.e, <calculator>) so the calculator is more flexible.
+  */
+
+  @supports (container-type: inline-size) {
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.33—0.47 */
+    --fluid-0\.33-0\.47: clamp(0.0206rem, 0.0007rem + 0.0848cqi, 0.0294rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.53—0.67 */
+    --fluid-0\.53-0\.67: clamp(0.0331rem, 0.0132rem + 0.0848cqi, 0.0419rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,0.67—0.93 */
+    --fluid-0\.67-0\.93: clamp(0.0419rem, 0.0049rem + 0.1576cqi, 0.0581rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,3—1 */
+    --fluid-3-1: clamp(0.0625rem, 0.4716rem + -1.2121cqi, 0.1875rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,5—10 */
+    --fluid-5-10: clamp(0.3125rem, -0.3977rem + 3.0303cqi, 0.625rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=320,540,10—24 */
+    --fluid-10-24: clamp(0.625rem, -0.6477rem + 6.3636cqi, 1.5rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,20—28 */
+    --fluid-20-28: clamp(1.25rem, 0.1136rem + 4.8485cqi, 1.75rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=320,540,20—32 */
+    --fluid-20-32: clamp(1.25rem, 0.1591rem + 5.4545cqi, 2rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,24—32 */
+    --fluid-24-32: clamp(1.5rem, 0.3636rem + 4.8485cqi, 2rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,32—40 */
+    --fluid-32-40: clamp(2rem, 0.8636rem + 4.8485cqi, 2.5rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,40—56 */
+    --fluid-40-56: clamp(2.5rem, 0.2273rem + 9.697cqi, 3.5rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=320,375,53—64 */
+    --fluid-53-64: clamp(3.3125rem, -0.6875rem + 20cqi, 4rem);
+    /* @link https://utopia.fyi/clamp/calculator?a=375,540,88—128 */
+    --fluid-88-128: clamp(5.5rem, -0.1818rem + 24.2424cqi, 8rem);
+  }
 }
 
 * {

--- a/src/assets/css/_base.css
+++ b/src/assets/css/_base.css
@@ -135,24 +135,44 @@ main {
   box-shadow: 0 0 0 var(--fluid-4-6) white;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --color-sheet: var(--color-mercury);
-    --color-text: var(--color-dune);
-    --color-switch-track: var(--color-grey-goose);
-    --color-switch-handle: var(--color-rust-orange);
-    --color-switch-handle-hover: var(--color-mango-orange);
-    --color-display-bg: var(--color-soft-peach);
-    --color-display-text: var(--color-dune);
-    --color-keypad: var(--color-grey-goose);
-    --color-key-text: var(--color-dune);
-    --color-key-bg: var(--color-platinum);
-    --color-key-shadow: var(--color-cement);
-    --color-key-primary-bg: var(--color-rust-orange);
-    --color-key-primary-hover: var(--color-mango-orange);
-    --color-key-primary-shadow: var(--color-rust-brown);
-    --color-key-secondary-bg: var(--color-greenish-blue);
-    --color-key-secondary-hover: var(--color-fountain-blue);
-    --color-key-secondary-shadow: var(--color-dark-green-blue);
-  }
+:root[data-theme="light"] {
+  --color-sheet: var(--color-mercury);
+  --color-text: var(--color-dune);
+  --color-switch-track: var(--color-grey-goose);
+  --color-switch-handle: var(--color-rust-orange);
+  --color-switch-handle-hover: var(--color-mango-orange);
+  --color-display-bg: var(--color-soft-peach);
+  --color-display-text: var(--color-dune);
+  --color-keypad: var(--color-grey-goose);
+  --color-key-text: var(--color-dune);
+  --color-key-bg: var(--color-platinum);
+  --color-key-shadow: var(--color-cement);
+  --color-key-primary-bg: var(--color-rust-orange);
+  --color-key-primary-hover: var(--color-mango-orange);
+  --color-key-primary-shadow: var(--color-rust-brown);
+  --color-key-secondary-bg: var(--color-greenish-blue);
+  --color-key-secondary-hover: var(--color-fountain-blue);
+  --color-key-secondary-shadow: var(--color-dark-green-blue);
+}
+
+:root[data-theme="purple"] {
+  --color-sheet: var(--color-black-rock);
+  --color-text: var(--color-banana-yellow);
+  --color-switch-track: var(--color-haiti);
+  --color-switch-handle: var(--color-aqua-blue);
+  --color-switch-handle-hover: var(--color-light-aquamarine);
+  --color-display-bg: var(--color-haiti);
+  --color-display-text: var(--color-banana-yellow);
+  --color-keypad: var(--color-haiti);
+  --color-key-text: var(--color-banana-yellow);
+  --color-key-bg: var(--color-dark-purple);
+  --color-key-hover: var(--color-purple-heart);
+  --color-key-shadow: var(--color-violet-eggplant);
+  --color-key-primary-text: var(--color-dark-jungle-green);
+  --color-key-primary-bg: var(--color-aqua-blue);
+  --color-key-primary-hover: var(--color-light-aquamarine);
+  --color-key-primary-shadow: var(--color-electric-blue);
+  --color-key-secondary-bg: var(--color-indigo);
+  --color-key-secondary-hover: var(--color-warm-purple);
+  --color-key-secondary-shadow: var(--color-neon-purple);
 }

--- a/src/assets/css/_base.css
+++ b/src/assets/css/_base.css
@@ -112,6 +112,10 @@
   --fluid-6-9: clamp(0.375rem, 0.309rem + 0.2817vi, 0.5625rem);
 }
 
+* {
+  transition: background-color 0.5s;
+}
+
 html {
   font-family: var(--text-sans);
   font-weight: var(--text-bold);

--- a/src/index.webc
+++ b/src/index.webc
@@ -7,11 +7,12 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
 
   <link rel="stylesheet" href="/assets/css/main.css" webc:keep>
-  <script type="module" src="/assets/js/main.js" webc:keep></script>
+  <script type="module" :src="getBundleFileUrl('js', 'defer')" webc:keep></script>
 
   <title>Frontend Mentor | Calculator app</title>
 
   <style @raw="getBundle('css')" webc:keep></style>
+  <script @raw="getBundle('js')" webc:keep></script>
 </head>
 <body>
   <main>


### PR DESCRIPTION
**Added:**
- Theme switcher with a fade transition when changing themes

**Fixed:**
- Layout for Safari in iOS <= 15.8 - since container query units are not supported, fluid values are initially declared using `vi` units, and then progressively enhanced to `cqi` units for browsers that have support.

**Improved:**
- Reduced layout shift in typography
- Minified js bundles with esbuild
- Added aria-labels to some keys to improve sr labels in the context of the calculator app
  - `DEL` - from "D-E-L" to "delete"
  - `.` - from "period" to "decimal point"
  - `/` - from "slash" to "divide"